### PR TITLE
Fix invalid charset

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: Italian <LL@li.org>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: src/Widgets/PreferencesDialog.vala:9


### PR DESCRIPTION
This fixes the following error while [building](https://github.com/Oowoosh0/pomodoro/actions/runs/3240988078/jobs/5312321605):

```
/usr/bin/meson --internal msgfmthelper ../data/pomodoro.desktop.in data/com.github.oowoosh0.pomodoro.desktop desktop /run/build/pomodoro/po
/run/build/pomodoro/po/it.po: warning: Charset "CHARSET" is not a portable encoding name.
                                       Message conversion to user's charset might not work.
msgfmt: present charset "CHARSET" is not a portable encoding name
```
